### PR TITLE
disable turbolinks for the header so that a user can leave ...

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="navbar navbar-fixed-top navbar-inverse">
+<header class="navbar navbar-fixed-top navbar-inverse" data-no-turbolink>
   <div class="container">
     <%= link_to "benedictation", root_path, id: "logo" %>
     <nav>

--- a/app/views/static_pages/room.html.erb
+++ b/app/views/static_pages/room.html.erb
@@ -54,8 +54,8 @@ var comm = new Icecomm('9gv3ODZorBS2kVuNwnugBeV432PcNX3Qn0HmW33ofxK/u5Xolu');
     });
 
     comm.on('disconnect', function(options) {
+      console.log('disconnect happening');
       document.getElementById(options.callerID).remove();
-      <!-- comm.close(); -->
     });
 
     comm.on('data', function(options) {
@@ -66,14 +66,16 @@ var comm = new Icecomm('9gv3ODZorBS2kVuNwnugBeV432PcNX3Qn0HmW33ofxK/u5Xolu');
   var $sendButton = $("#js-send-button-im");
   var $inputIM    = $("#js-input-im");
   var $chatBody   = $("#js-chat-body");
+  var localId = comm.getLocalID();
 
   $sendButton.on('click', sendIM);
   $inputIM.on('keypress', checkEnterKey);
 
-  <!-- //With Turbolinks pages will change without a full reload, so you can't rely on the usual window.beforepageunload event. Instead Turbolinks fires events on document to provide hooks into the lifecycle of the page.
-  $(document).on("page:fetch", function(){comm.close()}); //starting to fetch a new target page -->
+  <!-- With Turbolinks pages will change without a full reload, so you can't rely on the usual window.beforepageunload event. Instead Turbolinks fires events on document to provide hooks into the lifecycle of the page. -->
 
-
+  $(document).on("page:fetch", function(){
+  console.log('turbolinks page fetch event');
+  });
 
   // send a message
   function sendIM() {


### PR DESCRIPTION
...a chatroom by clicking links, and not just by closing the whole window. Turbolinks makes it so that clicking a header link just pastes a new body into the current html page, which means that the javascript event normally fired when refreshing or going to a new page doesn't fire. Because the icecomm disconnect event handler depends on this missing event, turbolinks makes disconnecting from our chatroom when visiting a new page very difficult, if not impossible. Turbolinks causes way more problems than it fixes, and doesn't really speed things up all that much anyway. For more info on this problem talk to me, or check out what they say [here](http://engineering.onlive.com/2014/02/14/turbolinks-the-best-thing-you-wont-ever-use-in-rails-4/) and [here](http://staal.io/blog/2013/01/18/dangers-of-turbolinks/). I only disabled Turbolinks for our header links, it still applies everywhere else for now.