### PR TITLE
Fixed all our terrible benedict recognization bugs

### DIFF
--- a/app/views/rooms/_room_icecomm_helper_functions.html.erb
+++ b/app/views/rooms/_room_icecomm_helper_functions.html.erb
@@ -6,8 +6,6 @@
 var comm = new Icecomm('9gv3ODZorBS2kVuNwnugBeV432PcNX3Qn0HmW33ofxK/u5Xolu');
 comm.connect(window.location.pathname);
 
-var numBenedicts = 1;
-
 
 
     // Set up the WebSocket in onload; so that it is available for use elsewhere.
@@ -26,6 +24,7 @@ var numBenedicts = 1;
             flag = 1;
         }
     recordSpeech.recording = 0;
+    startRecording(); //start listening for benedict again
     }
 
 window.onload = function() {
@@ -62,13 +61,10 @@ window.onload = function() {
 
                     // start recording after we hear "benedict"
                     var hypArray = newHyp.split(' ');
-                    console.log("hypothesis array: ",hypArray);
-                                        console.log("hypothesis array length: ",hypArray.length);
-
-                    console.log("numBenedicts recognized: ",numBenedicts);
-                    if(hypArray[hypArray.length - 1] === "BENEDICT" && hypArray.length > numBenedicts)
-                    {   numBenedicts  = numBenedicts + 1;
-                        recordSpeech();
+                    if(hypArray[hypArray.length - 1] === "BENEDICT" && recordSpeech.recording != 1)
+                    {   
+                        stopRecording(); // stop listening for benedict
+                        recordSpeech(); // record speech with other recorder
                     }
                 }
                 // This is the case when we have an error
@@ -122,5 +118,5 @@ window.onload = function() {
 // This is the list of words that need to be added to the recognizer
 // This follows the CMU dictionary format
 var wordList = [["ONE", "W AH N"], ["TWO", "T UW"], ["THREE", "TH R IY"], ["FOUR", "F AO R"], ["FIVE", "F AY V"], ["SIX", "S IH K S"], ["SEVEN", "S EH V AH N"], ["EIGHT", "EY T"], ["NINE", "N AY N"], ["ZERO", "Z IH R OW"], ["NEW-YORK", "N UW Y AO R K"], ["NEW-YORK-CITY", "N UW Y AO R K S IH T IY"], ["PARIS", "P AE R IH S"] , ["PARIS(2)", "P EH R IH S"], ["SHANGHAI", "SH AE NG HH AY"], ["SAN-FRANCISCO", "S AE N F R AE N S IH S K OW"], ["LONDON", "L AH N D AH N"], ["BERLIN", "B ER L IH N"], ["SUCKS", "S AH K S"], ["ROCKS", "R AA K S"], ["IS", "IH Z"], ["NOT", "N AA T"], ["GOOD", "G IH D"], ["GOOD(2)", "G UH D"], ["GREAT", "G R EY T"], ["WINDOWS", "W IH N D OW Z"], ["LINUX", "L IH N AH K S"], ["UNIX", "Y UW N IH K S"], ["MAC", "M AE K"], ["AND", "AE N D"], ["AND(2)", "AH N D"], ["O", "OW"], ["S", "EH S"], ["X", "EH K S"], ["BENEDICT", "B EH N AH D IH K T"]];
-var keywords = [{title: "ONE", g: "ONE"}, {title: "TWO", g: "TWO"}, {title: "NEW-YORK", g: "NEW-YORK"}, {title: "BENEDICT", g: "BENEDICT"}];
+var keywords = [{title: "BENEDICT", g: "BENEDICT"}];
 var keywordIds = [];

--- a/app/views/rooms/_room_icecomm_helper_functions.html.erb
+++ b/app/views/rooms/_room_icecomm_helper_functions.html.erb
@@ -56,12 +56,10 @@ window.onload = function() {
                 if (e.data.hasOwnProperty('hyp')) {
                     var newHyp = e.data.hyp;
                     if (e.data.hasOwnProperty('final') &&  e.data.final) newHyp = "Final: " + newHyp;
-                    console.log("New hypothesis from recognizer: " + newHyp);  // this is where we do something with it
-
-
+                    
                     // start recording after we hear "benedict"
                     var hypArray = newHyp.split(' ');
-                    if(hypArray[hypArray.length - 1] === "BENEDICT" && recordSpeech.recording != 1)
+                    if(hypArray[hypArray.length - 1] == "BENEDICT" && recordSpeech.recording != 1)
                     {   
                         stopRecording(); // stop listening for benedict
                         recordSpeech(); // record speech with other recorder

--- a/app/views/rooms/_room_pocketsphinx_helper_functions.html.erb
+++ b/app/views/rooms/_room_pocketsphinx_helper_functions.html.erb
@@ -53,7 +53,6 @@ intervalWait = setInterval(function() {
 
 // Record speech for 10s and export it as .wav to a server every 1s.
 function recordSpeech() {
-    console.log("recordspeech.recording: ",recordSpeech.recording);
     console.log("in recordSpeech function @@@");
     flag_ready = -1;
     // console.log("we are in record speech function @@@@");
@@ -62,17 +61,13 @@ function recordSpeech() {
     // if it is, we don't do anything.
     if( typeof recordSpeech.recording === 'undefined' ) {   // If it's not yet initialized:
         recordSpeech.recording = 0;                        // Initialize it.
-        // console.log("Initializing exportSpeech");
     }
     if( recordSpeech.recording == 1 ) {
-        // console.log("Called exportSpeech after recording already started; ");
         return; // Don't start recording if we are already.
     }
 
-    // console.log(recordSpeech.recording + " this is what was returned!!!");
-    // console.log("Recording!!!!!! @@@@@kevin")
-    speechRegRec.record(); //start recorder
-    console.log("starting to record 10 seconds of speech");
+    speechRegRec.record(); //start speechrec recorder
+    console.log("starting to record 5 seconds of speech");
     recordSpeech.recording = 1; // Set the flag indicating we're recording.
     ws.send("start"); //tell backend server to start listening
 
@@ -126,8 +121,6 @@ function recordSpeech() {
     // Changed setInterval to setTimeout -- maybe cleaner
     setTimeout(function() {
         speechRegRec.stop();
-        //recordSpeech.recording = 0; // Set the flag indicating we're no longer recording.
-        // console.log("Stopped recording speech");
         speechRegRec.exportWAV(function(blob) {
             speechRegRec.clear();
             ws.send(blob);
@@ -181,7 +174,7 @@ var feedWords = function(words) {
 // This initializes the recognizer. When it calls back, we add words
 var initRecognizer = function() {
     // You can pass parameters to the recognizer, such as : {command: 'initialize', data: [["-hmm", "my_model"], ["-fwdflat", "no"]]}
-    postRecognizerJob({command: 'initialize', data: [["-kws_threshold","2"]]},    // took off the threshold argument.
+    postRecognizerJob({command: 'initialize', data: [["-kws_threshold","1"]]},    // took off the threshold argument.
                     function() {
                                 if (recorder) recorder.consumers = [recognizer];
                                 feedWords(wordList);});
@@ -199,7 +192,6 @@ var recognizerReady = function() {
 // This current example only uses one keyword, so hardcoding id=0 is okay. This shouldn't stay this way.
 // I'm just trying to minimize confusing things right now.
 var startRecording = function()  {
-    numBenedicts = 0;
     console.log("In startRecording");
     if (recorder && recorder.start(0)) console.log("Recording");
     flag_ready = 1;

--- a/app/views/rooms/_room_pocketsphinx_helper_functions.html.erb
+++ b/app/views/rooms/_room_pocketsphinx_helper_functions.html.erb
@@ -64,10 +64,11 @@ function recordSpeech() {
     }
     if( recordSpeech.recording == 1 ) {
         return; // Don't start recording if we are already.
+        console.log("Tried to start recording speech when the recorder was already recording @@@")
     }
 
     speechRegRec.record(); //start speechrec recorder
-    console.log("starting to record 5 seconds of speech");
+    console.log("starting to record 5 seconds of speech @@@");
     recordSpeech.recording = 1; // Set the flag indicating we're recording.
     ws.send("start"); //tell backend server to start listening
 
@@ -174,7 +175,7 @@ var feedWords = function(words) {
 // This initializes the recognizer. When it calls back, we add words
 var initRecognizer = function() {
     // You can pass parameters to the recognizer, such as : {command: 'initialize', data: [["-hmm", "my_model"], ["-fwdflat", "no"]]}
-    postRecognizerJob({command: 'initialize', data: [["-kws_threshold","1"]]},    // took off the threshold argument.
+    postRecognizerJob({command: 'initialize', data: [["-kws_threshold","3"]]}, 
                     function() {
                                 if (recorder) recorder.consumers = [recognizer];
                                 feedWords(wordList);});
@@ -192,13 +193,13 @@ var recognizerReady = function() {
 // This current example only uses one keyword, so hardcoding id=0 is okay. This shouldn't stay this way.
 // I'm just trying to minimize confusing things right now.
 var startRecording = function()  {
-    console.log("In startRecording");
-    if (recorder && recorder.start(0)) console.log("Recording");
+    console.log("startRecording function");
+    if (recorder && recorder.start(0))
     flag_ready = 1;
 };
 // Stops recording
 var stopRecording = function() {
     recorder && recorder.stop();
-    console.log("Recording ended");
+    console.log("stopRecording function");
 };
 


### PR DESCRIPTION
Found out you can simply turn the pocketsphinx keyword recorder on and off to start/stop recognizing benedict and clear the hypothesis string (I thought doing this would mean reloading all the pocketsphinx shit, but nope!)

This means no more false positives from multiple benedict keyword recognizations in the pocketsphinx keyword recognizer's hypothesis string! Also makes it impossible to recognize benedict keyword if the speechrec recorder is recording. Will work even better once we add alternate Benedict pronounciations. 